### PR TITLE
Remove delayed_job. Add Sidekiq.

### DIFF
--- a/.example-env
+++ b/.example-env
@@ -2,8 +2,17 @@ DATABASE_URL=postgres://loader:mypassword@localhost:5432/loader_dev?schema_searc
 
 SYNC_DB_EVENTS_FREQUENCY_MINS=5
 
+LOG_LEVEL=DEBUG
+
 LANG=en_US.UTF-8
 
 NEWRELIC_AGENT_ENABLED=false
 
 PORT=3000
+
+REDIS_URL=redis://localhost:6379
+REDIS_POOL_SIZE=2
+
+SIDEKIQ_WORKERS=2
+
+SESSION_SECRET=topsecret

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,9 @@ gem 'rake'
 gem 'unicorn'
 gem 's3' #AWS buckets
 gem 'clockwork', '~> 2.0' #clock process
-gem 'delayed_job', '4.0.2' #job scheduling
-gem 'delayed_job_active_record', '4.0.1'
+gem 'sidekiq', '~> 5.0.4'
+gem 'sidekiq-limit_fetch'
+gem 'sidekiq-unique-jobs', '~> 5.0.10'
 gem 'newrelic_rpm' #app monitoring 
 gem 'foreman'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,11 +45,8 @@ GEM
     clockwork (2.0.2)
       activesupport
       tzinfo
-    delayed_job (4.0.2)
-      activesupport (>= 3.0, < 4.2)
-    delayed_job_active_record (4.0.1)
-      activerecord (>= 3.0, < 4.2)
-      delayed_job (>= 3.0, < 4.1)
+    concurrent-ruby (1.0.5)
+    connection_pool (2.2.1)
     enumerable-lazy (0.0.1)
     foreman (0.84.0)
       thor (~> 0.19.1)
@@ -107,8 +104,19 @@ GEM
       rack
     raindrops (0.15.0)
     rake (10.4.2)
+    redis (3.3.3)
     s3 (0.3.23)
       proxies (~> 0.2.0)
+    sidekiq (5.0.4)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (~> 3.3, >= 3.3.3)
+    sidekiq-limit_fetch (3.4.0)
+      sidekiq (>= 4)
+    sidekiq-unique-jobs (5.0.10)
+      sidekiq (>= 4.0, <= 6.0)
+      thor (~> 0)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -136,14 +144,15 @@ DEPENDENCIES
   activerecord4-redshift-adapter
   bcrypt
   clockwork (~> 2.0)
-  delayed_job (= 4.0.2)
-  delayed_job_active_record (= 4.0.1)
   foreman
   newrelic_rpm
   padrino (= 0.13.0)
   pg
   rake
   s3
+  sidekiq (~> 5.0.4)
+  sidekiq-limit_fetch
+  sidekiq-unique-jobs (~> 5.0.10)
   unicorn
   will_paginate!
 

--- a/Procfile.all
+++ b/Procfile.all
@@ -1,3 +1,3 @@
 web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb
 clock: bundle exec clockwork ./config/clock.rb
-worker: bundle exec rake jobs:work
+sidekiq: bundle exec sidekiq -C ./config/sidekiq.yml -r ./config/boot.rb

--- a/app/workers/clockwork_event_worker.rb
+++ b/app/workers/clockwork_event_worker.rb
@@ -1,0 +1,20 @@
+class ClockworkEventWorker
+  include Sidekiq::Worker
+  
+  # Some jobs are time sensitive, so only retry once before cancelling.
+  # The retry will be ~15s after the initial failure, according to Sidekiq docs:
+  # https://github.com/mperham/sidekiq/wiki/Error-Handling#automatic-job-retry
+  #
+  # Also, only allow one instance of each ClockworkEvent to be running at a time using sidekiq-unique-jobs
+  sidekiq_options retry: 1,
+                  unique: :until_and_while_executing,
+                  unique_args: :unique_args
+
+  def self.unique_args(args)
+    [ args[0] ]
+  end
+  
+  def perform(clockwork_event_id)
+    ClockworkEvent.find(clockwork_event_id).perform
+  end
+end

--- a/config.ru
+++ b/config.ru
@@ -4,6 +4,14 @@
 # This file can be used to start Padrino,
 # just execute it from the command line.
 
+require 'sidekiq/web'
+
 require File.expand_path("../config/boot.rb", __FILE__)
 
-run Padrino.application
+Sidekiq::Web.set(:session_secret, ENV['SESSION_SECRET'])
+Sidekiq::Web.use RedshiftLoader::SidekiqAuth
+
+run Rack::URLMap.new(
+  '/sidekiq' => Sidekiq::Web,
+  '/' => Padrino.application
+)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -25,5 +25,5 @@ end
 
 Padrino.load!
 
-Delayed::Worker.logger = Logger.new(STDOUT)
-Delayed::Worker.destroy_failed_jobs = false
+Padrino.require_dependencies "#{Padrino.root}/config/initializers/**/*.rb"
+require Padrino.root('config', 'workers.rb')

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,1 @@
+$redis = ConnectionPool::Wrapper.new(size: ENV['REDIS_POOL_SIZE'], timeout: 3) { Redis.connect(url: ENV['REDIS_URL']) }

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,10 @@
+require_relative '../../lib/sidekiq/clear_active_connections'
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV['REDIS_URL'] }
+  config.server_middleware do |chain|
+    chain.add Sidekiq::ClearActiveConnections
+  end
+end
+
+Sidekiq::Logging.logger.level = Logger.const_get((ENV['LOG_LEVEL'] || 'info').to_sym)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,4 @@
+:concurrency: <%= ENV['SIDEKIQ_WORKERS'] ? ENV['SIDEKIQ_WORKERS'].to_i : 2 %>
+:queues:
+  - default
+:dynamic: true

--- a/config/workers.rb
+++ b/config/workers.rb
@@ -1,0 +1,4 @@
+# workers.rb
+# runs sidekiq workers
+require File.expand_path('../boot.rb', __FILE__)
+Dir[File.expand_path('../../app/workers/**/*.rb', __FILE__)].each { |file| require file }

--- a/lib/sidekiq/clear_active_connections.rb
+++ b/lib/sidekiq/clear_active_connections.rb
@@ -1,0 +1,12 @@
+# I'm copying this middleware from Sidekiq because author said so
+# https://github.com/mperham/sidekiq/issues/3588#issuecomment-326010318
+
+module Sidekiq
+  class ClearActiveConnections
+    def call(*args)
+      yield
+    ensure
+      ::ActiveRecord::Base.clear_active_connections!
+    end
+  end
+end

--- a/lib/sidekiq_auth.rb
+++ b/lib/sidekiq_auth.rb
@@ -1,0 +1,24 @@
+module RedshiftLoader
+  class SidekiqAuth
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      session = env['rack.session']
+      forbidden = [403, { 'Content-Type' => 'text/html' }, ['You must be logged in to Redshift-Loader']]
+
+      if RACK_ENV != 'development'
+        return forbidden if session[:account_id].nil?
+
+        current_account = Account.find(session[:account_id]) if session[:account_id]
+
+        if current_account.nil? || !current_account.admin?
+          return forbidden
+        end
+      end
+
+      @app.call(env)
+    end
+  end
+end

--- a/models/clockwork_event.rb
+++ b/models/clockwork_event.rb
@@ -34,16 +34,12 @@ class ClockworkEvent < ActiveRecord::Base
 
     def schedule
       if running && (DateTime.now - last_run_at.to_datetime) * 1.day > 61.seconds
-          update_attribute(:running, false)
-          logger.info "ClockworkEvent '#{name}' stuck in running state - resetting..."
+        update_attribute(:running, false)
+        logger.info "ClockworkEvent '#{name}' stuck in running state - resetting..."
       end
 
       if !running
-          if queue
-              self.delay(:queue => job.queue).perform
-          else
-              self.delay.perform
-          end
+        ClockworkEventWorker.perform_async(self.id)
       end
     end
 


### PR DESCRIPTION
Disclaimer: A lot of this is copy-pasted from:

- https://github.com/mperham/sidekiq/wiki
- https://github.com/mhenrixon/sidekiq-unique-jobs#sidekiquniquejobs----
- https://github.com/the-open/identity

Note, that as Sidekiq doesn't support dynamic queues, the ability to mark different jobs for different queues is also lost. The `ClockworkEvent.queue` database field therefore becomes deprecated, and should be deleted from the DB and the code once we are confident that we won't need to back this change out!

Also note: *This code change means redshift-loader will have a dependency on a redis instance, so we need to set this up, along with the appropriate new ENV VARs prior to deploying live!*