### PR TITLE
Add option to run table copies as a separate Sidekiq job

### DIFF
--- a/app/workers/table_worker.rb
+++ b/app/workers/table_worker.rb
@@ -1,0 +1,22 @@
+class TableWorker
+  include Sidekiq::Worker
+  
+  # Some jobs are time sensitive, so only retry once before cancelling.
+  # The retry will be ~15s after the initial failure, according to Sidekiq docs:
+  # https://github.com/mperham/sidekiq/wiki/Error-Handling#automatic-job-retry
+  #
+  # Also, only allow one instance of each Table to be running at a time using sidekiq-unique-jobs
+  # (use unique until_executing because we want a table copy to be able to schedule
+  # another instance of itself in case there are too many rows to copy in one hit)
+  sidekiq_options retry: 1,
+                  unique: :until_executing,
+                  unique_args: :unique_args
+
+  def self.unique_args(args)
+    [ args[0] ]
+  end
+  
+  def perform(table_id)
+    Table.find(table_id).copy_now
+  end
+end

--- a/db/migrate/011_add_run_as_separate_job.rb
+++ b/db/migrate/011_add_run_as_separate_job.rb
@@ -1,0 +1,9 @@
+class AddRunAsSeparateJob < ActiveRecord::Migration
+
+  def change
+    change_table :tables do |t|
+      t.boolean :run_as_separate_job
+    end
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 10) do
+ActiveRecord::Schema.define(version: 11) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define(version: 10) do
     t.boolean  "delete_on_reset"
     t.text     "copy_mode"
     t.boolean  "disabled"
+    t.boolean  "run_as_separate_job"
   end
 
 end

--- a/models/job.rb
+++ b/models/job.rb
@@ -16,8 +16,8 @@ class Job < ActiveRecord::Base
         
         setup_connection
         tables.each do |table|
-            puts "Copying #{table.source_name} to #{table.destination_name}"
-            logger.info "Copying #{table.source_name} to #{table.destination_name}"
+            puts "Job #{name} - Copying #{table.source_name} to #{table.destination_name}"
+            logger.info "Job #{name} - Copying #{table.source_name} to #{table.destination_name}"
             table.copy
         end
         

--- a/models/table.rb
+++ b/models/table.rb
@@ -136,6 +136,15 @@ class Table < ActiveRecord::Base
     end
 
     def copy
+      if self.respond_to?(:run_as_separate_job) && run_as_separate_job
+        logger.info "Running copy of table #{source_name} as a separate job"
+        TableWorker.perform_async(self.id)
+      else
+        copy_now
+      end
+    end
+    
+    def copy_now
         started_at = Time.now
         return unless (self.check && self.enabled?)
         


### PR DESCRIPTION
Configurable per table, using the new table column `run_as_separate_job`