### PR TITLE
Refactor different table copy types into 3 different sub-classes

### DIFF
--- a/.example-env
+++ b/.example-env
@@ -24,3 +24,5 @@ S3_BUCKET_NAME=logs-for-etl-testing
 PARALLEL_PROCESSING_NODE_SLICES=12    # This should be set to the number of slices your redshift cluster has - see http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html#rs-about-clusters-and-nodes
 
 ADMIN_MODELS=Table,Job,ClockworkEvent
+
+IMPORT_ROW_LIMIT=1000000

--- a/app/workers/clockwork_event_worker.rb
+++ b/app/workers/clockwork_event_worker.rb
@@ -9,7 +9,7 @@ class ClockworkEventWorker
   sidekiq_options retry: 1,
                   unique: :until_executed,
                   unique_args: :unique_args,
-                  lock_expiration: (2 * 60 * 60)  # 2 hours
+                  lock_expiration: (1 * 60 * 60)  # 1 hour
 
   def self.unique_args(args)
     [ args[0] ]

--- a/app/workers/table_worker.rb
+++ b/app/workers/table_worker.rb
@@ -9,7 +9,7 @@ class TableWorker
   sidekiq_options retry: 1,
                   unique: :until_executed,
                   unique_args: :unique_args,
-                  lock_expiration: (2 * 60 * 60)  # 2 hours
+                  lock_expiration: (1 * 60 * 60)  # 1 hour
 
   # Lock on the lock_name arg
   def self.unique_args(args)

--- a/db/migrate/012_add_table_copy_type.rb
+++ b/db/migrate/012_add_table_copy_type.rb
@@ -1,0 +1,9 @@
+class AddTableCopyType < ActiveRecord::Migration
+
+  def change
+    change_table :tables do |t|
+      t.text :table_copy_type
+    end
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 11) do
+ActiveRecord::Schema.define(version: 12) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 11) do
     t.text     "copy_mode"
     t.boolean  "disabled"
     t.boolean  "run_as_separate_job"
+    t.text     "table_copy_type"
   end
 
 end

--- a/models/full_sync_table.rb
+++ b/models/full_sync_table.rb
@@ -1,0 +1,100 @@
+class FullSyncTable < Table
+  # FullSyncTable is for tables where we want to periodically do a full copy of
+  # the source table. The main use-case for this is where it is important to copy
+  # over the fact that rows have been deleted from the source database. Detecting
+  # deletions is not possible with either InsertOnlyTable or UpdateAndInsertTable.
+  #
+  # NOTE: While InsertOnlyTable and UpdateAndInsertTable incrementally keep the
+  # destination table up to date, FullSyncTable incrementally builds up a complete
+  # replacement table, and when complete swaps it out for the original, and then
+  # starts the whole process again.
+  #
+  # Eg. Assume initially we have a populated destination table.
+  # When the copy job runs for FullSyncTable, it will check if a table called
+  # "#{destination_name}_full_sync_table_swap" exists. If not, this will be
+  # created, and a rows will be incrementally copied over to this table. When a
+  # run of the copy job detects that all rows have been copied to the swap
+  # table, it will swap out the existing table for the swap table in a
+  # transaction. Next time the copy job runs, the swap table will not be preset,
+  # so will be re-created, and the cycle starts again.
+  #
+  # This means that the value of max_updated_key reflects the current max 
+  # primary key of the SWAP table - this will cycle depending upon how far the
+  # current full table sync is through the copy process. This also means that
+  # if changing the type of a table from FullSyncTable to one of the other
+  # types, you are strongly advised to manually set the max_primary_key and
+  # max_updated_key at the same time as changing the type or risk duplicate
+  # and/or missing rows!
+  
+  
+  def where_statement_for_source
+    # For FullSyncTable, rows might be updated or deleted, but this will be picked
+    # up on the next iteration of re-building the swap table, so only care about
+    # finding actual new rows here.
+    "WHERE #{primary_key} > #{max_primary_key}"
+  end
+  
+  def order_by_statement_for_source
+    "ORDER BY #{primary_key} ASC"
+  end
+  
+  def apply_resets
+    if reset_updated_key || delete_on_reset
+      logger.warn "reset_updated_key is not supported for #{source_name} because it is a FullSyncTable"
+    end
+  end
+  
+  def check_for_time_travelling_data
+    if time_travel_scan_back_period
+      logger.warn "time_travel_scan_back_period is not supported for #{source_name} because it is a FullSyncTable"
+    end
+  end
+  
+  def update_max_values(table_name = self.destination_name)
+    sql = "SELECT MAX(#{primary_key}) as max_primary_key
+           FROM #{table_name}"
+    x = destination_connection.execute(sql).first
+
+    logger.info "max_primary_key is now #{x['max_primary_key']} for #{source_name}"
+    update_attributes({ max_primary_key: x['max_primary_key'].to_i })
+  end
+  
+  def swap_table_name
+    "full_sync_swap_table_#{destination_name}"
+  end
+  
+  def old_table_name
+    "full_sync_old_table_#{destination_name}"
+  end
+  
+  def pre_copy_steps
+    # Need to ensure the swap table is created before any copying
+    destination_connection.execute("CREATE TABLE IF NOT EXISTS #{swap_table_name} (LIKE #{destination_name});")
+  end
+  
+  def post_copy_steps(result)
+    # Check if all data is copied to the swap table. If so, replace the original table with the now up-to-date swap.
+    # Also delete the old version of the table if exists, and rename the current version to old (because dropping the
+    # current version immediately will break currently executing queries, renaming to old will let them complete).
+    if result.count < import_row_limit
+      logger.info "Swap table #{swap_table_name} has all data from #{source_name}, renaming #{destination_name} to #{old_table_name} and renaming #{swap_table_name} to #{destination_name}"
+      sql = "BEGIN;
+               DROP TABLE IF EXISTS #{old_table_name};
+               ALTER TABLE #{destination_name} RENAME TO #{old_table_name};
+               ALTER TABLE #{swap_table_name} RENAME TO #{destination_name};
+             END;"
+      destination_connection.execute(sql)
+      
+      # Completed a full copy cycle, so reset the keys so we start again from scratch on the next run
+      update_attribute(:max_updated_key, MIN_UPDATED_KEY)
+      update_attribute(:max_primary_key, MIN_PRIMARY_KEY)
+    end
+  end
+  
+  def merge_to_table_name
+    # For FullSyncTable we want to merge results into the swap table, which will be switched later
+    # (see the post_copy_steps method)
+    swap_table_name
+  end
+  
+end

--- a/models/full_sync_table.rb
+++ b/models/full_sync_table.rb
@@ -11,11 +11,11 @@ class FullSyncTable < Table
   #
   # Eg. Assume initially we have a populated destination table.
   # When the copy job runs for FullSyncTable, it will check if a table called
-  # "#{destination_name}_full_sync_table_swap" exists. If not, this will be
-  # created, and a rows will be incrementally copied over to this table. When a
+  # "full_sync_swap_table_#{destination_name}" exists. If not, this will be
+  # created, and rows will be incrementally copied over to this table. When a
   # run of the copy job detects that all rows have been copied to the swap
   # table, it will swap out the existing table for the swap table in a
-  # transaction. Next time the copy job runs, the swap table will not be preset,
+  # transaction. Next time the copy job runs, the swap table will not be present,
   # so will be re-created, and the cycle starts again.
   #
   # This means that the value of max_updated_key reflects the current max 

--- a/models/insert_only_table.rb
+++ b/models/insert_only_table.rb
@@ -1,0 +1,36 @@
+class InsertOnlyTable < Table
+  # InsertOnlyTable is for tables where data is never updated after being inserted
+  # OR where even if a record was updated after insertion, we don't care about
+  # copying across the updates to the record.
+  
+  
+  def where_statement_for_source
+    # For InsertOnlyTables we assume rows are never updated in the source DB after
+    # creation (and/or if they are, we don't care about copying the updates across!)
+    # So we simply look for records with a higher primary_key
+    "WHERE #{primary_key} > #{max_primary_key}"
+  end
+  
+  def order_by_statement_for_source
+    "ORDER BY #{primary_key} ASC"
+  end
+  
+  def check_for_time_travelling_data
+    if time_travel_scan_back_period
+      logger.warn "time_travel_scan_back_period is not supported for #{source_name} because it is an InsertOnlyTable"
+    end
+  end
+  
+  def update_max_values(table_name = self.destination_name)
+    # For InsertOnlyTables we don't set the value of the max_updated_key because we don't
+    # use it to select new rows, and if the table type switched to UpdateAndInsert it would
+    # need to scan *all* records for more recently updated rows!
+    sql = "SELECT MAX(#{primary_key}) as max_primary_key
+           FROM #{table_name}"
+    x = destination_connection.execute(sql).first
+
+    logger.info "max_primary_key is now #{x['max_primary_key']} for #{source_name}"
+    update_attributes({ max_primary_key: x['max_primary_key'].to_i })
+  end
+  
+end

--- a/models/update_and_insert_table.rb
+++ b/models/update_and_insert_table.rb
@@ -1,0 +1,60 @@
+class UpdateAndInsertTable < Table
+  # UpdateAndInsertTable is for tables where we want to copy over both new rows
+  # AND rows which have been updated.
+  #
+  # NOTE: it is assumed that the updated_key (usually the updated_at ActiveRecord
+  # column) is updated every time a record changes. If you manually update a
+  # record (eg. by directly connecting to the source database) and forget to update
+  # the update_key, the updates to the row WILL NOT BE COPIED ACROSS!
+  
+  
+  def where_statement_for_source
+    # For UpdateAndInsertTables we want to find all rows which have been updated
+    # more recently than the last time we ran. Because each run picks up a limited
+    # number of rows (import_row_limit), it's possible we also missed some rows
+    # with the same updated_key, but a higher primary_key, so also look for those
+    "WHERE ( #{updated_key} >= '#{max_updated_key.strftime('%Y-%m-%d %H:%M:%S.%N')}' AND #{primary_key} > #{max_primary_key} )
+     OR #{updated_key} > '#{max_updated_key.strftime('%Y-%m-%d %H:%M:%S.%N')}'"
+  end
+  
+  def order_by_statement_for_source
+    "ORDER BY #{updated_key}, #{primary_key} ASC"
+  end
+  
+  def check_for_time_travelling_data
+    # If data with an older 'updated_at' is inserted into a table after newer data has been loaded it will not be picked up.
+    # We can check to see if this has happened (heuristically) by looking at the count of data before the current
+    # max_updated_key in both databases. If everything is normal then count of destination.updated_key will be >= count of
+    # source.updated_key. Therefore if count destination.updated_key < count source.updated_key we assume that data has time
+    # travelled and rewind the max_updated_key
+    if time_travel_scan_back_period
+      sql = "SELECT COUNT(*) as count FROM #{destination_name}
+             WHERE #{updated_key} >= '#{max_updated_key - time_travel_scan_back_period}'
+             AND #{updated_key} < '#{max_updated_key}'"
+      destination_count = destination_connection.execute(sql).first['count'].to_i
+
+      sql = "SELECT COUNT(*) as count FROM #{source_name}
+             WHERE #{updated_key} >= '#{max_updated_key - time_travel_scan_back_period}'
+             AND #{updated_key} < '#{max_updated_key}'"
+      source_count = source_connection.execute(sql).first['count'].to_i
+
+      if source_count > destination_count
+        update_attribute(:reset_updated_key, max_updated_key - time_travel_scan_back_period)
+      end
+    end
+  end
+  
+  def update_max_values(table_name = self.destination_name)
+    sql = "SELECT MAX(#{primary_key}) as max_primary_key,
+                  MAX(#{updated_key}) as max_updated_key
+           FROM #{table_name}"
+    x = destination_connection.execute(sql).first
+
+    logger.info "max_primary_key is now #{x['max_primary_key']} and max_updated_key is now #{x['max_updated_key']} for #{source_name}"
+    update_attributes({
+        max_primary_key: x['max_primary_key'].to_i,
+        max_updated_key: x['max_updated_key']
+        })
+  end
+  
+end


### PR DESCRIPTION
Using the unfortunately named "Single Table Inheritance" feature of ActiveRecord.

Notes for deployment - after deploying, the code will not function until:
a) The new `COPY_VIA_S3` environment variable is set to true (not copying via S3 is only recommended for dev, so we don't need to have a dev S3 & redshift)
b) The DB migration is run
c) All tables are updated to have an appropriate value for the `table_copy_type` column, such that Single Table Inheritance knows which subclass of `Table` to instantiate. The possible values are: `UpdateAndInsertTable`, `InsertOnlyTable`, and `FullSyncTable`.

The functionality of UpdateAndInsert and InsertOnly tables _should_ remain the same as at present, **however** there are some notable differences!

1) Updating the max values (`max_primary_key` and `max_updated_key`) is now delegated to the 3 subclasses, so differs for each, see the `update_max_values` method in the subclasses:
- ~~`UpdateAndInsertTable` simply finds the max `primary_key` and max `updated_at`. Previously it found the max `updated_at` and then the max `primary_key` _which happened to have that same updated at_ which didn't seem to make sense. In cases where the most recently updated row was very old and had a very low `primary_key`, the `max_primary_key` would be set extremely low for seemingly no good reason...~~ **Update** - I finally worked out why this code was the way it was (without screwing up prod!), see very long comment in `UpdateAndInsertTable.update_max_values` if you want to know why...
- `InsertOnlyTable` now **only** selects the max `primary_key` and does not update the `max_updated_key`, since it doesn't use `max_updated_key` anyway, and if someone were to modify the `copy_table_type` from `InsertOnlyTable` to `UpdateAndInsertTable` the `max_updated_key` would then be incorrect and misleading.
- `FullTableSync` also only selects the max `primary_key`, it also doesn't use the `max_updated_key`. Both `max_primary_key and `max_updated_key`

2) The `check_for_time_travelling_data` is now explicitly disabled for `InsertOnlyTable`s as it would not work as expected and would result in duplicate rows. For similar reasons, it is disabled for `FullSyncTable`s as well.

3) `InsertOnlyTable`s will now also do the (theoretically unnecessary) check of deleting any rows from the destination table which are duplicated in the temp table (see the `merge_results` method). This is to ensure no rows with duplicate Primary Key are copied over. Again, if the table truly is insert only *and* no-one is manually messing around with the `max_primary_key` *and* no weird errors are happening, this shouldn't be necessary anyway, but it shouldn't be harmful or slow things down much.

This has been run locally in all 3 modes without the `COPY_VIA_S3` env var on to enable local testing. All 3 modes do work, although this doesn't mean there are edge case errors!